### PR TITLE
Initial implementation for tx & prover search

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -11,8 +11,8 @@ type Stats struct {
 
 type Event struct {
 	State     string    `json:"state"`
-	TxID      string    `json:"tx_id"`
-	ProverID  string    `json:"prover_id"`
+	TxID      string    `db:"tx_id",json:"tx_id"`
+	ProverID  string    `db:"prover_id",json:"prover_id"`
 	Tag       string    `json:"tag"`
 	Timestamp time.Time `json:"timestamp"`
 }

--- a/model/model.go
+++ b/model/model.go
@@ -11,8 +11,8 @@ type Stats struct {
 
 type Event struct {
 	State     string    `json:"state"`
-	TxID      string    `db:"tx_id",json:"tx_id"`
-	ProverID  string    `db:"prover_id",json:"prover_id"`
+	TxID      string    `db:"tx_id" json:"tx_id"`
+	ProverID  string    `db:"prover_id" json:"prover_id"`
 	Tag       string    `json:"tag"`
 	Timestamp time.Time `json:"timestamp"`
 }


### PR DESCRIPTION
Devnet explorer has a search field where user can give transaction hash or prover program hash as an input and the backend should return 50 newest events for that query.