### PR TITLE
Fix stats aggregations day comparison

### DIFF
--- a/stats/aggregator.go
+++ b/stats/aggregator.go
@@ -45,7 +45,7 @@ func (a *Aggregator) Run() error {
 		select {
 		case <-t.C:
 			now := time.Now()
-			if now.Day() > lastRan.Day() {
+			if monotonicDay(now) > monotonicDay(lastRan) {
 				slog.Info("aggregating stats", slog.Time("last_ran", lastRan), slog.Time("now", now))
 				if err := a.store.AggregateStats(now); err != nil {
 					slog.Error("failed to aggregate stats", slog.String("error", err.Error()))
@@ -58,6 +58,11 @@ func (a *Aggregator) Run() error {
 			return nil
 		}
 	}
+}
+
+func monotonicDay(t time.Time) int64 {
+	const secsInDay = 24 * 60 * 60
+	return t.Unix() / secsInDay
 }
 
 func (a *Aggregator) Stop() error {

--- a/stats/aggregator_test.go
+++ b/stats/aggregator_test.go
@@ -1,0 +1,27 @@
+package stats
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestMonotonicDay(t *testing.T) {
+	now := time.Now()
+	prev := now.AddDate(0, 0, -1)
+
+	for i := 0; i < 1000; i++ {
+		if monotonicDay(now) <= monotonicDay(prev) {
+			t.Fatalf("monotonicDay(now) %q <= monotonicDay(prev) %q", now.Format(time.DateTime), prev.Format(time.DateTime))
+		}
+
+		// Update prev with current time.
+		prev = now
+
+		// Add one day to current day.
+		now = now.AddDate(0, 0, 1)
+
+		// Add random number of minutes to day, to cause random time of day shifting.
+		now = now.Add(time.Minute * time.Duration(rand.Int63n(240)))
+	}
+}


### PR DESCRIPTION
`time.Day()` returns "the day of the month" and the stats aggregator used this as a check if `time.Now().Day()` has increased from the last iterations `time.Now().Day()`. Depending on which day of month the service was started, this leads to situation where stats are only updated in the end of the month.

This change adds `monotonicDay()` which computes number of days since [Epoch](https://en.wikipedia.org/wiki/Unix_time) for given `time.Time` and fixes the comparison.